### PR TITLE
Update github-pages.yaml to trigger on pushes to main rather than the…

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   push:
-    branches: new-feature/user-guide
+    branches: main
 
 name: Quarto Publish
 


### PR DESCRIPTION
## Overview of changes

The work to create the user guide got merged in whilst the user guide workflow was still only triggering from that development branch. I'm just switching that over to main as the trigger now.

## Why are these changes being made?

So the workflow runs as required

